### PR TITLE
fix: allow importing as ES module

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,15 @@
   ],
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "engines": {
     "node": ">=16.7"
   },


### PR DESCRIPTION
Specify [`package.json`'s conditional exports](https://nodejs.org/api/packages.html#conditional-exports) to allow the plugin to be imported as an ES module.

fixes #7 